### PR TITLE
mkuimage: advise GOAMD64=v1 for GOARCH=amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,33 @@ $ mkuimage -files "$HOME/hello.ko:etc/hello.ko" -files "$HOME/hello2.ko:etc/hell
 $ qemu-system-x86_64 -kernel /boot/vmlinuz-$(uname -r) -initrd /tmp/initramfs.linux_amd64.cpio
 ```
 
+## AMD64 Architecture Level
+
+Before building for AMD64, verify that the command
+
+```shell
+go env GOAMD64
+```
+
+prints `v1`. A [`GOAMD64` setting](https://go.dev/wiki/MinimumRequirements#amd64)
+of any higher version may produce such binaries that don't execute on old AMD64
+processors (including the default CPU model of QEMU).
+
+`GOAMD64` can be reset to `v1` with one of the following methods:
+
+*   through the `GOAMD64` environment variable:
+
+    ```shell
+    export GOAMD64=v1
+    ```
+
+*   through `go env` (only takes effect if the `GOAMD64` environment variable
+    is not set):
+
+    ```shell
+    go env -w GOAMD64=v1
+    ```
+
 ## Cross Compilation (targeting different architectures and OSes)
 
 Just like standard Go tooling, cross compilation is easy and supported.


### PR DESCRIPTION
If the user builds an initrd for amd64, and their golang toolchain is configured for an amd64 ABI version greater than 1, then issue a warning.

Binaries built for GOAMD64=v2+ may crash with an #UD exception on old CPUs, or exit immediately (gracefully) with an error message like "This program can only be run on AMD64 processors with v2 microarchitecture support" [1]. Such a dysfunctional "init" (gobusybox) binary renders a u-root initrd effectively unbootable. qemu-system-x86_64 with no particular "-cpu" option is affected by this, for example.

GOAMD64 defaults to v1 [2], but it may be overridden in at least three places (in increasing order of importance):

- the system-wide "go.env" file, such as "/usr/lib/golang/go.env",

- the user's "go.env" file, such as "$HOME/.config/go/env",

- the env var GOAMD64.

For example, RHEL9 and its derivative distros set GOAMD64 to v2 in "/usr/lib/golang/go.env".

It seems like the canonical way for deducing GOAMD64 programmatically is to invoke "go env GOAMD64" [3].

[1] https://github.com/golang/go/commit/8c8baad927b2
[2] https://go.dev/wiki/MinimumRequirements#amd64
[3] https://github.com/golang/go/issues/72791