### PR TITLE
Never follow files for extraFiles

### DIFF
--- a/uimage/uimage.go
+++ b/uimage/uimage.go
@@ -798,7 +798,7 @@ func ParseExtraFiles(l *llog.Logger, archive *initramfs.Files, extraFiles []stri
 		if err != nil {
 			return fmt.Errorf("couldn't find absolute path for %q: %w", src, err)
 		}
-		if err := archive.AddFile(src, dst); err != nil {
+		if err := archive.AddFileNoFollow(src, dst); err != nil {
 			return fmt.Errorf("couldn't add %q to archive: %w", file, err)
 		}
 


### PR DESCRIPTION
-files files should be installed as-is, not followed. People frequently want to add symlinks.