### PR TITLE
Add -skip-ldd flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ mkuimage \
 
 You may also include additional files in the initramfs using the `-files` flag.
 
-If you add binaries with `-files` are listed, their ldd dependencies will be
-included as well.
+If you add binaries with `-files`, their ldd dependencies will be
+included as well by default. See below for how to disable.
 
 ```shell
 $ mkuimage -files /bin/bash
@@ -259,6 +259,11 @@ executing your currently booted kernel:
 $ mkuimage -files "$HOME/hello.ko:etc/hello.ko" -files "$HOME/hello2.ko:etc/hello2.ko" ./u-root/cmds/core/*
 $ qemu-system-x86_64 -kernel /boot/vmlinuz-$(uname -r) -initrd /tmp/initramfs.linux_amd64.cpio
 ```
+
+Use `-skip-ldd` to not automatically include ldd dependencies for binary files. This can be useful for
+- Reproducible Builds: Ensures builds don't depend on the host system's libraries
+- Cross-compilation: When host libraries are incompatible with target architecture
+- Controlled Dependencies: When you want to manually specify exact library versions
 
 ## AMD64 Architecture Level
 

--- a/uimage/mkuimage/uflags.go
+++ b/uimage/mkuimage/uflags.go
@@ -110,7 +110,8 @@ type Flags struct {
 	Uinit *string
 	Shell *string
 
-	Files []string
+	Files   []string
+	SkipLDD bool
 
 	BaseArchive     string
 	ArchiveFormat   string
@@ -125,6 +126,9 @@ func (f *Flags) Modifiers(packages ...string) ([]uimage.Modifier, error) {
 	m := []uimage.Modifier{
 		uimage.WithFiles(f.Files...),
 		uimage.WithExistingInit(f.UseExistingInit),
+	}
+	if f.SkipLDD {
+		m = append(m, uimage.WithSkipLDD())
 	}
 	if f.TempDir != nil {
 		m = append(m, uimage.WithTempDir(*f.TempDir))
@@ -167,6 +171,7 @@ func (f *Flags) RegisterFlags(fs *flag.FlagSet) {
 	fs.Var(&optionalStringVar{&f.Shell}, "defaultsh", "Default shell. Can be an absolute path or a Go command name. Use defaultsh=\"\" if you don't want the symlink.")
 
 	fs.Var((*uflag.Strings)(&f.Files), "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be specified multiple times.")
+	fs.BoolVar(&f.SkipLDD, "skip-ldd", f.SkipLDD, "Skip automatic shared library dependency resolution for files. You must manually specify all required libraries.")
 
 	fs.StringVar(&f.BaseArchive, "base", f.BaseArchive, "Base archive to add files to. By default, this is a couple of directories like /bin, /etc, etc. Has a default internally supplied set of files; use base=/dev/null if you don't want any base files.")
 	fs.StringVar(&f.ArchiveFormat, "format", f.ArchiveFormat, "Archival input (for -base) and output (for -o) format.")

--- a/uimage/mkuimage/uflags_test.go
+++ b/uimage/mkuimage/uflags_test.go
@@ -94,6 +94,26 @@ func TestFlags(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: []string{"-build=bb", "-skip-ldd"},
+			want: &Flags{
+				SkipLDD: true,
+				Commands: CommandFlags{
+					Builder:   "bb",
+					BuildOpts: &golang.BuildOpts{},
+				},
+			},
+		},
+		{
+			input: []string{"-build=bb", "-skip-ldd=false"},
+			want: &Flags{
+				SkipLDD: false,
+				Commands: CommandFlags{
+					Builder:   "bb",
+					BuildOpts: &golang.BuildOpts{},
+				},
+			},
+		},
 	} {
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		f := &Flags{}
@@ -126,6 +146,38 @@ func TestFlagModifiers(t *testing.T) {
 			cmds: []string{"foo"},
 			want: &uimage.Opts{
 				Env: golang.Default(),
+				Commands: []uimage.Commands{
+					{
+						Builder:   &builder.GBBBuilder{},
+						BuildOpts: &golang.BuildOpts{},
+					},
+				},
+			},
+		},
+		{
+			// Test that -skip-ldd flag sets SkipLDD to true
+			input: []string{"-build=bb", "-format=cpio", "-skip-ldd"},
+			base:  []uimage.Modifier{},
+			cmds:  []string{"foo"},
+			want: &uimage.Opts{
+				Env:     golang.Default(),
+				SkipLDD: true,
+				Commands: []uimage.Commands{
+					{
+						Builder:   &builder.GBBBuilder{},
+						BuildOpts: &golang.BuildOpts{},
+					},
+				},
+			},
+		},
+		{
+			// Test that without -skip-ldd flag, SkipLDD remains false
+			input: []string{"-build=bb", "-format=cpio"},
+			base:  []uimage.Modifier{},
+			cmds:  []string{"foo"},
+			want: &uimage.Opts{
+				Env:     golang.Default(),
+				SkipLDD: false,
 				Commands: []uimage.Commands{
 					{
 						Builder:   &builder.GBBBuilder{},


### PR DESCRIPTION
The option to skip resolving ldd dependencies of binary files was already implemented, but could only be controlled programmatically. This commit adds the appropriate flag to the mkuimage command.

Closes #42 