### PR TITLE
bump recommended Go versions

### DIFF
--- a/uimage/mkuimage/cmd.go
+++ b/uimage/mkuimage/cmd.go
@@ -21,9 +21,9 @@ import (
 )
 
 var recommendedVersions = []string{
-	"go1.20",
-	"go1.21",
-	"go1.22",
+	"go1.23",
+	"go1.24",
+	"go1.25",
 }
 
 func isRecommendedVersion(v string) bool {


### PR DESCRIPTION
u-root is currently using 1.25 in CI, and so the warning regarding the version is being printed all the time, which may be surprising.